### PR TITLE
fix(deno): add version requirements to npm specifiers

### DIFF
--- a/template-deno-lit/vite.config.mjs
+++ b/template-deno-lit/vite.config.mjs
@@ -1,6 +1,6 @@
-import { defineConfig } from 'npm:vite'
+import { defineConfig } from 'npm:vite@^3.1.3'
 
-import 'npm:lit'
+import 'npm:lit@2.4'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-lit/vite.config.mjs
+++ b/template-deno-lit/vite.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from 'npm:vite@^3.1.3'
 
-import 'npm:lit@2.4'
+import 'npm:lit@^2.4'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-preact/vite.config.mjs
+++ b/template-deno-preact/vite.config.mjs
@@ -1,8 +1,8 @@
 import { defineConfig } from 'npm:vite@^3.1.3'
-import preact from 'npm:@preact/preset-vite@2.4'
+import preact from 'npm:@preact/preset-vite@^2.4'
 
-import 'npm:preact@10.11'
-import 'npm:preact@10.11/hooks'
+import 'npm:preact@^10.11'
+import 'npm:preact@^10.11/hooks'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-preact/vite.config.mjs
+++ b/template-deno-preact/vite.config.mjs
@@ -1,8 +1,8 @@
-import { defineConfig } from 'npm:vite'
-import preact from 'npm:@preact/preset-vite'
+import { defineConfig } from 'npm:vite@^3.1.3'
+import preact from 'npm:@preact/preset-vite@2.4'
 
-import 'npm:preact'
-import 'npm:preact/hooks'
+import 'npm:preact@10.11'
+import 'npm:preact@10.11/hooks'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-react/vite.config.mjs
+++ b/template-deno-react/vite.config.mjs
@@ -1,8 +1,8 @@
-import { defineConfig } from 'npm:vite'
-import react from 'npm:@vitejs/plugin-react'
+import { defineConfig } from 'npm:vite@^3.1.3'
+import react from 'npm:@vitejs/plugin-react@2.1'
 
-import 'npm:react'
-import 'npm:react-dom/client'
+import 'npm:react@18.2'
+import 'npm:react-dom/client@18.2'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-react/vite.config.mjs
+++ b/template-deno-react/vite.config.mjs
@@ -1,8 +1,8 @@
 import { defineConfig } from 'npm:vite@^3.1.3'
-import react from 'npm:@vitejs/plugin-react@2.1'
+import react from 'npm:@vitejs/plugin-react@^2.1'
 
-import 'npm:react@18.2'
-import 'npm:react-dom/client@18.2'
+import 'npm:react@^18.2'
+import 'npm:react-dom/client@^18.2'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-solid/vite.config.mjs
+++ b/template-deno-solid/vite.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'npm:vite'
-import solid from 'npm:vite-plugin-solid'
+import { defineConfig } from 'npm:vite@^3.1.3'
+import solid from 'npm:vite-plugin-solid@^2.3.9'
 
-import 'npm:solid-js'
+import 'npm:solid-js@^1.5.9'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-svelte/vite.config.mjs
+++ b/template-deno-svelte/vite.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'npm:vite'
-import { svelte } from 'npm:@sveltejs/vite-plugin-svelte'
+import { defineConfig } from 'npm:vite@^3.1.3'
+import { svelte } from 'npm:@sveltejs/vite-plugin-svelte@^1.0.8'
 
-import 'npm:svelte'
+import 'npm:svelte@^3.50.1'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/template-deno-vue/vite.config.mjs
+++ b/template-deno-vue/vite.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig } from 'npm:vite'
-import vue from 'npm:@vitejs/plugin-vue'
+import { defineConfig } from 'npm:vite@^3.1.3'
+import vue from 'npm:@vitejs/plugin-vue@^3.2.39'
 
-import 'npm:vue'
+import 'npm:vue@^3.2.39'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
These were essentially all `*` before, which isn't ideal.

cc @bartlomieju 