### PR TITLE
fix denols linting

### DIFF
--- a/template-deno-solid-ts/deno.json
+++ b/template-deno-solid-ts/deno.json
@@ -4,5 +4,15 @@
     "build": "deno run -A --node-modules-dir npm:vite build",
     "preview": "deno run -A --node-modules-dir npm:vite preview",
     "serve": "deno run --allow-net --allow-read https://deno.land/std@0.157.0/http/file_server.ts dist/"
+  },
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "npm:solid-js",
+    "lib": [
+      "es6",
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable"
+    ]
   }
 }

--- a/template-deno-solid-ts/src/App.tsx
+++ b/template-deno-solid-ts/src/App.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from 'solid-js'
+import { createSignal } from 'npm:solid-js'
 import solidLogo from './assets/solid.svg'
 import './App.css'
 

--- a/template-deno-solid-ts/src/main.tsx
+++ b/template-deno-solid-ts/src/main.tsx
@@ -1,7 +1,13 @@
 /* @refresh reload */
-import { render } from 'solid-js/web'
+import { render } from 'npm:solid-js/web'
 
-import App from './App'
+import App from './App.tsx'
 import './index.css'
 
-render(() => <App />, document.getElementById('root'))
+const root = document.getElementById('root')
+
+if (root == null) {
+  throw new Error("can not find #root element")
+}	
+
+render(() => <App />, root)


### PR DESCRIPTION
This commit fixes linting errors in deno-solid-ts. The project was running fine but it was throwing a ton of errors reported by denols language server. To fix that:

* Added the lib compiler option to the deno.json file following the [Deno manual's instructions](https://deno.land/manual@v1.30.0/advanced/typescript/configuration#using-the-lib-property).
* Also added the jsx and jsxImportSource options to the deno.json file, using the [Solid.js Typescript Configuration Guide](https://www.solidjs.com/guides/typescript#configuring-typescript) as a reference.
* Minor import statement fixes.