### PR TITLE
fix(ssr): close #38, correct ssr-manifest.json's path

### DIFF
--- a/template-ssr-preact-ts/server.js
+++ b/template-ssr-preact-ts/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-preact/server.js
+++ b/template-ssr-preact/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-react-ts/server.js
+++ b/template-ssr-react-ts/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-react/server.js
+++ b/template-ssr-react/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-solid-ts/server.js
+++ b/template-ssr-solid-ts/server.js
@@ -12,7 +12,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-solid/server.js
+++ b/template-ssr-solid/server.js
@@ -12,7 +12,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-svelte-ts/server.js
+++ b/template-ssr-svelte-ts/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-svelte/server.js
+++ b/template-ssr-svelte/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-vanilla-ts/server.js
+++ b/template-ssr-vanilla-ts/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-vanilla/server.js
+++ b/template-ssr-vanilla/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-vue-ts/server.js
+++ b/template-ssr-vue-ts/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server

--- a/template-ssr-vue/server.js
+++ b/template-ssr-vue/server.js
@@ -11,7 +11,7 @@ const templateHtml = isProduction
   ? await fs.readFile('./dist/client/index.html', 'utf-8')
   : ''
 const ssrManifest = isProduction
-  ? await fs.readFile('./dist/client/ssr-manifest.json', 'utf-8')
+  ? await fs.readFile('./dist/client/.vite/ssr-manifest.json', 'utf-8')
   : undefined
 
 // Create http server


### PR DESCRIPTION
https://vitejs.dev/guide/migration.html#manifest-files-are-now-generated-in-vite-directory-by-default

> Manifest files are now generated in .vite directory by default
> In Vite 4, the manifest files ([build.manifest](https://vitejs.dev/config/build-options#build-manifest) and [build.ssrManifest](https://vitejs.dev/config/build-options#build-ssrmanifest)) were generated in the root of [build.outDir](https://vitejs.dev/config/build-options#build-outdir) by default.
> 
> From Vite 5, they will be generated in the .vite directory in the build.outDir by default. This change helps deconflict public files with the same manifest file names when they are copied to the build.outDir.