### PR TITLE
fix: add react intellisense support in Deno templates

### DIFF
--- a/template-deno-react/deno.json
+++ b/template-deno-react/deno.json
@@ -1,4 +1,11 @@
 {
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "imports": {
+    "react": "https://esm.sh/react@18.2.0",
+    "react-dom": "https://esm.sh/react-dom@18.2.0"
+  },
   "tasks": {
     "dev": "deno run -A --node-modules-dir npm:vite",
     "build": "deno run -A --node-modules-dir npm:vite build",

--- a/template-deno-react/src/main.jsx
+++ b/template-deno-react/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
+import ReactDOM from 'react-dom'
+import App from './App.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Description

Currently in multiple React+Deno projects the intellisense doesn't work out of the box. It needs configuration which should be included in the templates out of the box.

I am willing to fix this in all the Deno+React projects (TS & JS), and majority of them involve updating the `deno.json` file and a little updates to `import` statements. For now, I have made these changes only in `template-deno-react` if you are satisfied with the changes, I can incorporate other repositories via more commits.

> Related Issues: #32 

### Current Changes:

- add `.jsx` extension to imports.
- add `imports` and `compilerOptions` in `deno.json` to support intellisense support while working on React project.
- fixes the type & intellisense errors.