### PR TITLE
fix(ssr): wrap streamed React output in <main> to enable proper streaming with Suspense

### DIFF
--- a/template-ssr-react-streaming-ts/server.js
+++ b/template-ssr-react-streaming-ts/server.js
@@ -72,6 +72,10 @@ app.use('*all', async (req, res) => {
           },
         })
 
+        const styleTag = `<link rel="stylesheet" href="./src/App.css">`
+
+        template = template.replace('<!--app-head-->', styleTag)
+
         const [htmlStart, htmlEnd] = template.split(`<!--app-html-->`)
 
         res.write(htmlStart)

--- a/template-ssr-react-streaming-ts/src/entry-server.tsx
+++ b/template-ssr-react-streaming-ts/src/entry-server.tsx
@@ -8,7 +8,9 @@ import App from './App'
 export function render(_url: string, options?: RenderToPipeableStreamOptions) {
   return renderToPipeableStream(
     <StrictMode>
-      <App />
+      <main>
+        <App />
+      </main>
     </StrictMode>,
     options,
   )

--- a/template-ssr-react-streaming/server.js
+++ b/template-ssr-react-streaming/server.js
@@ -72,6 +72,10 @@ app.use('*all', async (req, res) => {
           },
         })
 
+        const styleTag = `<link rel="stylesheet" href="./src/App.css">`
+
+        template = template.replace('<!--app-head-->', styleTag)
+
         const [htmlStart, htmlEnd] = template.split(`<!--app-html-->`)
 
         res.write(htmlStart)

--- a/template-ssr-react-streaming/src/entry-server.jsx
+++ b/template-ssr-react-streaming/src/entry-server.jsx
@@ -9,7 +9,9 @@ import App from './App'
 export function render(_url, options) {
   return renderToPipeableStream(
     <StrictMode>
-      <App />
+        <main>
+          <App />
+        </main>
     </StrictMode>,
     options,
   )


### PR DESCRIPTION
## 📝 Description :

This PR updates the `entry-server.jsx` file to wrap the rendered React tree in a `<main>` element. This change is necessary to ensure streaming works correctly when using React Suspense and lazy components in server-side rendering (SSR) mode.

## 💡 Problem

After several tests it would seem that when using `React.lazy()` and `<Suspense>` near the root of the app (especially as the first element in `<body>`), React’s streaming behavior is blocked.

React must emit valid HTML — but if the top-level of the stream starts with a suspended element (like a lazy-loaded component), it cannot begin flushing output until that suspense resolves, even for the fallback.

## ✅ Proposed solution

By wrapping the rendered app in a structural tag like `<main>`, we give React a valid HTML shell to flush immediately. This allows:
- Immediate rendering of fallback content inside `<Suspense>`
- Progressive hydration and streaming
- Improved compatibility with `renderToPipeableStream`
	
**💥 FOUC (Flash of Unstyled Content)**

During server-side rendering with streaming, a FOUC can occur if stylesheets are not loaded before content starts rendering. This typically happens when the `<link rel="stylesheet">` tag is injected too late in the HTML stream — after the main app content has already started piping. As a result, users briefly see unstyled HTML, followed by abrupt layout shifts when the CSS finally loads. To prevent this, it’s important to stream critical `<link>` tags as early as possible, ideally before calling `pipe()`, so the browser can begin loading styles in parallel with the HTML. This ensures consistent visual rendering and avoids perceptible flicker during hydration.

**😊 Let me know if you have any questions or comments about my PR 🙏🏼**