### PR TITLE
Expose nested variants as frameworks

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,9 +335,14 @@ const FRAMEWORKS = [
   },
 ]
 
-const TEMPLATES = FRAMEWORKS.map(
-  (f) => (f.variants && f.variants.map((v) => v.name)) || [f.name],
-).reduce((a, b) => a.concat(b), [])
+function flattenVariants(framework) {
+  if (framework.variants) {
+    return framework.variants.flatMap((variant) => flattenVariants(variant))
+  }
+  return [framework.name]
+}
+
+const TEMPLATES = FRAMEWORKS.flatMap(flattenVariants)
 
 const renameFiles = {
   _gitignore: '.gitignore',


### PR DESCRIPTION
I wanted to run `npm create vite-extra@latest . -- --template=ssr-react-streaming-ts` programmatically (without any user interaction required), but I was getting `"ssr-react-streaming-ts" isn't a valid template` because the nested variants were not exposed as templates to choose from.

This PR addresses that.